### PR TITLE
Fix build with Clang13

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -166,14 +166,6 @@ else ifeq ($(call isTargetOs, bsd), true)
   endif
 
   ifeq ($(TOOLCHAIN_TYPE), clang)
-    ifeq ($(call isTargetCpu, x86), true)
-      ifneq ($(DEBUG_LEVEL), slowdebug)
-        # hotspot/jtreg/compiler/c2/Test8062950.java test fails on x86
-        # with clang when parse2.cpp is optimized above -O1
-        BUILD_LIBJVM_parse2.cpp_CXXFLAGS := -O1
-      endif
-    endif
-
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the
     # default level. The Clang compiler issues a compile
@@ -189,14 +181,30 @@ else ifeq ($(call isTargetOs, bsd), true)
         sharedRuntimeTrans.cpp \
         loopTransform.cpp \
         unsafe.cpp \
-        parse2.cpp \
         #
 
-    ifeq ($(OPENJDK_TARGET_CPU), aarch64)
-      JVM_PRECOMPILED_HEADER_EXCLUDE += \
-          memnode.cpp
-          #
-      BUILD_LIBJVM_memnode.cpp_CXXFLAGS := -O0
+    ifneq ($(DEBUG_LEVEL), slowdebug)
+      ifeq ($(call isTargetCpu, x86), true)
+        # hotspot/jtreg/compiler/c2/Test8062950.java test fails on x86
+        # with clang when parse2.cpp is optimized above -O1
+        BUILD_LIBJVM_parse2.cpp_CXXFLAGS := -O1
+
+        JVM_PRECOMPILED_HEADER_EXCLUDE += \
+            parse2.cpp \
+            #
+      endif
+
+      ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+        BUILD_LIBJVM_memnode.cpp_CXXFLAGS := -O0
+
+        # needed for clang 13
+        BUILD_LIBJVM_immediate_$(HOTSPOT_TARGET_CPU).cpp_CXXFLAGS := -O1
+
+        JVM_PRECOMPILED_HEADER_EXCLUDE += \
+            memnode.cpp \
+            immediate_$(HOTSPOT_TARGET_CPU).cpp \
+            #
+      endif
     endif
   endif
 

--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -58,10 +58,16 @@ class RegisterImpl: public AbstractRegisterImpl {
   VMReg as_VMReg();
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
   const char* name() const;
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding_nocheck() const                 { return (intptr_t)this; }
 };
 
@@ -152,7 +158,13 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
   FloatRegister successor() const                          { return as_FloatRegister((encoding() + 1) % 32); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding_nocheck() const                         { return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
@@ -254,7 +266,13 @@ class PRegisterImpl: public AbstractRegisterImpl {
   PRegister successor() const     { return as_PRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding_nocheck() const  { return (intptr_t)this; }
   bool  is_valid() const          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -63,6 +63,9 @@ class RegisterImpl: public AbstractRegisterImpl {
   inline VMReg as_VMReg();
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
@@ -118,6 +121,9 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
   FloatRegister successor() const                          { return as_FloatRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
@@ -157,6 +163,9 @@ class XMMRegisterImpl: public AbstractRegisterImpl {
   XMMRegister successor() const                          { return as_XMMRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register (%d)", (int)(intptr_t)this ); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
@@ -232,6 +241,9 @@ public:
   KRegister successor() const                          { return as_KRegister(encoding() + 1); }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int   encoding() const                          { assert(is_valid(), "invalid register (%d)", (int)(intptr_t)this); return (intptr_t)this; }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;

--- a/src/hotspot/cpu/zero/register_zero.hpp
+++ b/src/hotspot/cpu/zero/register_zero.hpp
@@ -57,6 +57,9 @@ class RegisterImpl : public AbstractRegisterImpl {
   }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int encoding() const {
     assert(is_valid(), "invalid register");
     return (intptr_t)this;
@@ -92,6 +95,9 @@ class FloatRegisterImpl : public AbstractRegisterImpl {
   }
 
   // accessors
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int encoding() const {
     assert(is_valid(), "invalid register");
     return (intptr_t)this;

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -207,6 +207,9 @@ class LIR_OprDesc: public CompilationResourceObj {
   friend class LIR_OprFact;
 
   // Conversion
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   intptr_t value() const                         { return (intptr_t) this; }
 
   bool check_value_mask(intptr_t mask, intptr_t masked_value) const {

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -111,6 +111,9 @@ public:
   }
 
 
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   intptr_t value() const         {return (intptr_t) this; }
 
   void print_on(outputStream* st) const;

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -37,6 +37,9 @@ class Metadata : public MetaspaceObj {
   NOT_PRODUCT(Metadata() : _valid(0) {})
   NOT_PRODUCT(bool is_valid() const { return _valid == 0; })
 
+#if defined(__clang_major__) && (__clang_major__ >= 13)
+  NOINLINE
+#endif
   int identity_hash()                { return (int)(uintptr_t)this; }
 
   virtual bool is_metadata()           const { return true; }


### PR DESCRIPTION
The jdk uses tagged pointers on 'this' which clang knows to
be aligned and then optimizes away the tags.  Work around
using 'this' as a tagged pointer by preventing inlining
with clang 13 and lowering optimization level when that 
wasn't sufficient. 