### PR TITLE
Various minor corrections

### DIFF
--- a/.github/actions/do-build-vm/action.yml
+++ b/.github/actions/do-build-vm/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -83,7 +83,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: 'Restore Cached VM Packages'
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -183,7 +183,7 @@ jobs:
           sudo df -h
 
       - name: 'Save VM Packages'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "7.8"
+      vm-release: '7.9'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.prepare.outputs.openbsd-x64 == 'true'
@@ -348,7 +348,7 @@ jobs:
     with:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 7.8
+      vm-release: 7.9
       vm-arch: x86_64
 
   test-freebsd-x64:

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -221,7 +221,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -229,7 +229,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Restore Cached VM Packages
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -238,7 +238,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -246,7 +246,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -189,6 +189,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_heapShared.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_management.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_notificationThread.cpp := bitwise-instead-of-logical, \
+    DISABLED_WARNINGS_clang_os_bsd_aarch64.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_os_posix.cpp := mismatched-tags missing-field-initializers, \
     DISABLED_WARNINGS_clang_postaloc.cpp := tautological-undefined-compare, \
     DISABLED_WARNINGS_clang_serviceThread.cpp := bitwise-instead-of-logical, \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -716,8 +716,12 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
     LIBSPLASHSCREEN_EXCLUDE_SRC_PATTERNS := /unix/
   endif
 
-  LIBSPLASHSCREEN_CFLAGS += -DSPLASHSCREEN -DPNG_NO_MMX_CODE \
-                            -DPNG_ARM_NEON_OPT=0 -DPNG_ARM_NEON_IMPLEMENTATION=0
+  ifeq ($(USE_EXTERNAL_LIBPNG), false)
+    LIBSPLASHSCREEN_CFLAGS += -DPNG_NO_MMX_CODE -DPNG_ARM_NEON_OPT=0 \
+                              -DPNG_ARM_NEON_IMPLEMENTATION=0
+  endif
+
+  LIBSPLASHSCREEN_CFLAGS += -DSPLASHSCREEN
 
   ifeq ($(call isTargetOs, linux), true)
     ifeq ($(call isTargetCpuArch, ppc), true)

--- a/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
+++ b/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
@@ -339,7 +339,7 @@ Java_sun_java2d_xr_XRBackendNative_createPixmap(JNIEnv *env, jobject this,
 JNIEXPORT jint JNICALL
 Java_sun_java2d_xr_XRBackendNative_createPictureNative
  (JNIEnv *env, jclass cls, jint drawable, jlong formatPtr) {
-  XRenderPictureAttributes pict_attr;
+  XRenderPictureAttributes pict_attr = { 0 };
   return XRenderCreatePicture(awt_display, (Drawable) drawable,
                               (XRenderPictFormat *) jlong_to_ptr(formatPtr),
                                0, &pict_attr);

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -34,6 +34,13 @@
 #include "util.h"
 #include "error_messages.h"
 
+#define RESTARTABLE(_cmd, _result) do { \
+  do { \
+    _result = _cmd; \
+  } while((_result == -1) && (errno == EINTR)); \
+} while(0)
+
+
 static char *skipWhitespace(char *p) {
     while ((*p != '\0') && isspace(*p)) {
         p++;
@@ -72,6 +79,9 @@ closeDescriptors(void)
 {
 #if defined(__FreeBSD__)
     closefrom(STDERR_FILENO + 1);
+#elif defined(_BSDONLY_SOURCE)
+    int err;
+    RESTARTABLE(closefrom(STDERR_FILENO + 1), err);
 #else
     DIR *dp;
     struct dirent *dirp;


### PR DESCRIPTION
Except for the GHA changes, these are from patches in OpenBSD packages - moving them up stream here:
GHA: Use OpenBSD 7.9 for building and testing
GHA: Upgrade Node.js 20 to 24
Use restartable closefrom(2) for BSD, except FreeBSD which uses
closefrom(2) that does not need restarts.
Fix building with external libpng on aarch64
Allow building with warnings as errors on BSD aarch64
Fix building with clang 22:
error: variable 'pict_attr' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]