### PR TITLE
BSD Serviceability

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -50,6 +50,8 @@ public class DynLibsTest {
             osDependentBaseString = "lib%s.so";
         } else if (Platform.isLinux()) {
             osDependentBaseString = "lib%s.so";
+        } else if (Platform.isBSD()) {
+            osDependentBaseString = "lib%s.so";
         } else if (Platform.isOSX()) {
             osDependentBaseString = "lib%s.dylib";
         } else if (Platform.isWindows()) {

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -53,7 +53,8 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland");
+                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland",
+                "isOpenBSD");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -138,6 +138,10 @@ public class Platform {
         return osName.toLowerCase().endsWith("bsd");
     }
 
+    public static boolean isOpenBSD() {
+        return osName.toLowerCase().equals("openbsd");
+    }
+
     private static boolean isOs(String osname) {
         return osName.toLowerCase(ROOT).startsWith(osname.toLowerCase(ROOT));
     }
@@ -256,6 +260,8 @@ public class Platform {
             return false; // SA is not enabled.
         }
         if (isAix()) {
+            return false; // SA not implemented.
+        } else if (isOpenBSD()) {
             return false; // SA not implemented.
         } else if (isLinux()) {
             if (isS390x() || isARM()) {


### PR DESCRIPTION
Two differences in jdk17u compared to jdk21u
`loadObjectContainingPC` already does a linear search of the loaded objects
Add BSD support to DynLibsTest.java