### PR TITLE
Backport BSD jdk/tier1 part1 test fixes

### DIFF
--- a/src/java.base/bsd/native/libjava/ProcessHandleImpl_bsd.c
+++ b/src/java.base/bsd/native/libjava/ProcessHandleImpl_bsd.c
@@ -46,11 +46,6 @@
 #include <sys/user.h>  // For kinfo_proc
 #endif
 
-#if defined(__OpenBSD__)
-#include <sys/event.h> // For kqueue
-#include <sys/time.h>  // For kqueue
-#endif
-
 /* TODO: Refactor. */
 #define RESTARTABLE(_cmd, _result) do { \
   do { \
@@ -487,45 +482,3 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
     free(args);
 #endif
 }
-
-#if defined(__OpenBSD__)
-int os_waitForProcessExitNoReap(pid_t pid) {
-    int kq, ret;
-    struct kevent evSet;
-    struct kevent event;
-
-    kq = kqueue();
-    if (kq == -1)
-        return -1;
-
-    /* block to clean up kq fd */
-    do {
-        EV_SET(&evSet, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
-
-        RESTARTABLE(kevent(kq, &evSet, 1, NULL, 0, NULL), ret);
-        if (ret == -1) {
-            /*
-             * If process doesn't exist (or is a zombie), return 0
-             * since it is not possible to return actual exit status.
-             */
-            if (errno == ESRCH)
-                ret = 0;
-            break;
-        }
-
-        RESTARTABLE(kevent(kq, NULL, 0, &event, 1, NULL), ret);
-        if (ret == -1)
-           break;
-
-        if (event.flags & EV_ERROR) {
-            ret = -1;
-            break;
-        }
-
-        ret = event.data;
-    } while(0);
-
-    close(kq);
-    return ret;
-}
-#endif

--- a/src/java.base/bsd/native/libjava/ProcessHandleImpl_bsd.c
+++ b/src/java.base/bsd/native/libjava/ProcessHandleImpl_bsd.c
@@ -334,8 +334,10 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
     mib[3] = KERN_PROC_ARGV;
 
     if (sysctl(mib, 4, NULL, &size, NULL, 0) == -1) {
-        JNU_ThrowByNameWithLastError(env,
-            "java/lang/RuntimeException", "sysctl failed");
+        if (errno != EINVAL && errno != ESRCH && errno != EPERM) {
+            JNU_ThrowByNameWithLastError(env,
+                "java/lang/RuntimeException", "sysctl failed");
+        }
         return;
     }
 
@@ -353,7 +355,7 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
         jobject argsArray;
 
         if (sysctl(mib, 4, args, &size, NULL, 0) == -1) {
-            if (errno != EINVAL) {
+            if (errno != EINVAL && errno != ESRCH && errno != EPERM) {
                 JNU_ThrowByNameWithLastError(env,
                     "java/lang/RuntimeException", "sysctl failed");
             }

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -252,9 +252,6 @@ Java_java_lang_ProcessHandleImpl_waitForProcessExit0(JNIEnv* env,
             return status;
         }
      } else {
-#if defined(__OpenBSD__) && OpenBSD < 202304
-        return os_waitForProcessExitNoReap(pid);
-#else
         /*
          * Wait for the child process to exit without reaping the exitValue.
          * waitid() is standard on all POSIX platforms.
@@ -286,7 +283,6 @@ Java_java_lang_ProcessHandleImpl_waitForProcessExit0(JNIEnv* env,
               */
              return siginfo.si_status;
         }
-#endif
     }
 }
 

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
@@ -78,7 +78,3 @@ extern void unix_fillArgArray(JNIEnv *env, jobject jinfo, int nargs, char *cp,
                               char *argsEnd, jstring cmdexe, char *cmdline);
 
 extern void os_initNative(JNIEnv *env, jclass clazz);
-
-#if defined(__OpenBSD__) && OpenBSD < 202304
-extern int os_waitForProcessExitNoReap(pid_t pid);
-#endif

--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -302,10 +302,13 @@ public class InfoTest {
                     Assert.assertTrue(command.endsWith(expected), "Command: expected: \'" +
                             expected + "\', actual: " + command);
 
-                    // Verify the command exists and is executable
-                    File exe = new File(command);
-                    Assert.assertTrue(exe.exists(), "command must exist: " + exe);
-                    Assert.assertTrue(exe.canExecute(), "command must be executable: " + exe);
+                    // OpenBSD's kernel does not preserve the full exe path at execution time
+                    if (!Platform.isOpenBSD()) {
+                        // Verify the command exists and is executable
+                        File exe = new File(command);
+                        Assert.assertTrue(exe.exists(), "command must exist: " + exe);
+                        Assert.assertTrue(exe.canExecute(), "command must be executable: " + exe);
+                    }
                 }
                 if (info.arguments().isPresent()) {
                     String[] args = info.arguments().get();

--- a/test/jdk/sun/misc/SunMiscSignalTest.java
+++ b/test/jdk/sun/misc/SunMiscSignalTest.java
@@ -141,6 +141,11 @@ public class SunMiscSignalTest {
                 {"INFO", IsSupported.YES, CanRegister.YES, CanRaise.YES, invokedXrs},
         };
 
+        Object[][] posixBSDSignals = {
+                {"BUS",  IsSupported.YES, CanRegister.YES, CanRaise.YES, invokedXrs},
+                {"INFO", IsSupported.YES, CanRegister.YES, CanRaise.YES, invokedXrs},
+        };
+
         Object[][] windowsSignals = {
                 {"HUP",  IsSupported.NO, CanRegister.NO, CanRaise.NO, Invoked.NO},
                 {"QUIT", IsSupported.NO, CanRegister.NO, CanRaise.NO, Invoked.NO},
@@ -165,7 +170,8 @@ public class SunMiscSignalTest {
         };
 
         Object[][] combinedPosixSignals = concatArrays(posixSignals,
-                                                       (Platform.isOSX() ? posixOSXSignals : posixNonOSXSignals));
+                                                       (Platform.isOSX() ? posixOSXSignals :
+                                                            (Platform.isBSD() ? posixBSDSignals : posixNonOSXSignals)));
         return concatArrays(commonSignals, (Platform.isWindows() ? windowsSignals : combinedPosixSignals));
     }
 


### PR DESCRIPTION
Back port commits that fix jdk/tier1 part1 test failures on OpenBSD and FreeBSD from jdk25u.

jdk17u does not have jdk/java/lang/Thread/virtual tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
