### PR TITLE
Use FreeBSD 14.4 in GHA workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,7 +309,7 @@ jobs:
       platform: freebsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "14.3"
+      vm-release: "14.4"
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.prepare.outputs.freebsd-x64 == 'true'
@@ -360,7 +360,7 @@ jobs:
     with:
       platform: freebsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 14.3
+      vm-release: 14.4
       vm-arch: x86_64
 
   test-windows-x64:


### PR DESCRIPTION
Backported from battleblow/jdk:bsd-port branch.

This work is sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
