### PR TITLE
Fix build with clang 22:

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;


### PR DESCRIPTION
error: variable 'dummy' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]

---------
- [] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
