### PR TITLE
Fix os::naked_short_nanosleep on OpenBSD when < 20 miliseconds.

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2059,6 +2059,35 @@ void os::naked_yield() {
   sched_yield();
 }
 
+#ifdef __OpenBSD__
+// OpenBSD does not provide sleep functionality with nanosecond resolution, so we
+// try to approximate this with spinning combined with spin pause for sleeps
+// less then 20 ms
+void os::naked_short_nanosleep(jlong ns) {
+  assert(ns > -1 && ns < NANOUNITS, "Un-interruptable sleep, short time use only");
+
+  // if >= 20 ms use nanosleep
+  if (ns >= 20 * NANOUNITS_PER_MILLIUNIT) {
+    struct timespec req, rem;
+    req.tv_sec = 0;
+    req.tv_nsec = ns;
+    while(::nanosleep(&req, &rem) == -1) {
+      if (errno == EINTR)
+        req = rem;
+      else
+        break;
+    }
+    return;
+  }
+
+  // less then 20 ms need to use busy wait
+  int64_t start = os::javaTimeNanos();
+  do {
+      SpinPause();
+  } while (os::javaTimeNanos() - start < ns);
+}
+#endif // __OpenBSD__
+
 ////////////////////////////////////////////////////////////////////////////////
 // thread priority support
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -918,6 +918,7 @@ void os::infinite_sleep() {
   }
 }
 
+#ifndef __OpenBSD__
 void os::naked_short_nanosleep(jlong ns) {
   struct timespec req;
   assert(ns > -1 && ns < NANOUNITS, "Un-interruptable sleep, short time use only");
@@ -926,6 +927,7 @@ void os::naked_short_nanosleep(jlong ns) {
   ::nanosleep(&req, NULL);
   return;
 }
+#endif
 
 void os::naked_short_sleep(jlong ms) {
   assert(ms < MILLIUNITS, "Un-interruptable sleep, short time use only");


### PR DESCRIPTION
nanosleep(2) on OpenBSD is currently accurate down to 20 miliseconds. Below 20 miliseconds, use a busy loop with SpinPause.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
