### PR TITLE
Backports to fix jdk tier1 part 3 errors

### DIFF
--- a/make/modules/jdk.incubator.foreign/Lib.gmk
+++ b/make/modules/jdk.incubator.foreign/Lib.gmk
@@ -35,6 +35,20 @@ ifeq ($(call isTargetOs, linux), true)
       LIBS := $(LIBCXX) -lc -lm -ldl, \
   ))
 
+else ifeq ($(call isTargetOs, bsd), true)
+
+  ifeq ($(OPENJDK_TARGET_OS_ENV), bsd.openbsd)
+    BSDLIBC= -lc
+  endif
+
+  $(eval $(call SetupJdkLibrary, BUILD_SYSLOOKUPLIB, \
+      NAME := syslookup, \
+      CFLAGS := $(CFLAGS_JDKLIB), \
+      CXXFLAGS := $(CXXFLAGS_JDKLIB), \
+      LDFLAGS := $(LDFLAGS_JDKLIB) -Wl$(COMMA)--no-as-needed, \
+      LIBS := $(LIBCXX) $(LIBDL) $(LIBM) $(BSDLIBC), \
+  ))
+
 else ifeq ($(call isTargetOs, windows), false)
 
   $(eval $(call SetupJdkLibrary, BUILD_SYSLOOKUPLIB, \

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -98,7 +98,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
         long alignedSize = alignmentBytes > MAX_MALLOC_ALIGN ?
                 bytesSize + (alignmentBytes - 1) :
-                bytesSize;
+                Math.max(bytesSize, alignmentBytes);
 
         nioAccess.reserveMemory(alignedSize, bytesSize);
 

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -53,6 +53,12 @@ public class TestMemoryAlignment {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(aligned, scope);
             vh.set(segment, -42);
+
+            // Allocate another segment and fill it with data to
+            // check that the first segment is not overwritten
+            MemorySegment nextSegment = MemorySegment.allocateNative(aligned, scope);
+            vh.set(nextSegment, 0xffffff);
+
             int val = (int)vh.get(segment);
             assertEquals(val, -42);
         }


### PR DESCRIPTION
* Explicitly link in libc into libsyslookup
* 8371637: allocateNativeInternal sometimes return incorrectly aligned memory

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
